### PR TITLE
Update webpack DefinePlugin environment variables

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -46,9 +46,8 @@ module.exports = {
       filename: 'index.html'
     }),
     new webpack.DefinePlugin({
-      'process.env': {
-        NODE_ENV: JSON.stringify(process.env.NODE_ENV || 'development')
-      }
+      'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'development'),
+      'process.env.VUE_APP_MODE': JSON.stringify(process.env.NODE_ENV || 'development')
     })
   ],
   resolve: {


### PR DESCRIPTION
## Changes Made

### Webpack Configuration Updates

- **Simplified environment variable definition**: Changed from nested object structure to direct property assignment for `process.env.NODE_ENV`
- **Added new environment variable**: Introduced `process.env.VUE_APP_MODE` with the same fallback value as `NODE_ENV`

### Technical Details

The webpack DefinePlugin configuration was modified to:
- Replace the nested `'process.env': { NODE_ENV: ... }` structure with direct `'process.env.NODE_ENV'` assignment
- Add `'process.env.VUE_APP_MODE'` variable that defaults to the same value as `NODE_ENV` (development if not set)

Both variables maintain the same fallback behavior, defaulting to 'development' when `process.env.NODE_ENV` is not defined.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/c4e1f7fd6cfe4acda4f9cbdbe0ed4aae/echo-realm)

👀 [Preview Link](https://c4e1f7fd6cfe4acda4f9cbdbe0ed4aae-echo-realm.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>c4e1f7fd6cfe4acda4f9cbdbe0ed4aae</projectId>-->
<!--<branchName>echo-realm</branchName>-->