### PR TITLE
Update profile section: add sign in/up, wishlist, remove trust indicators

### DIFF
--- a/src/components/auth/AuthModal.vue
+++ b/src/components/auth/AuthModal.vue
@@ -1207,40 +1207,6 @@ export default {
   text-decoration: underline;
 }
 
-/* Trust Section */
-.trust-section {
-  display: flex;
-  justify-content: center;
-  gap: 32px;
-  padding-top: 24px;
-  border-top: 1px solid var(--gray-200);
-}
-
-.trust-item {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 6px;
-  text-align: center;
-}
-
-.trust-item i {
-  color: var(--primary-500);
-  font-size: 20px;
-  background: var(--primary-50);
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.trust-item span {
-  font-size: 12px;
-  color: var(--gray-600);
-  font-weight: 600;
-}
 
 /* Forgot Password Modal */
 .forgot-overlay {

--- a/src/components/auth/AuthModal.vue
+++ b/src/components/auth/AuthModal.vue
@@ -1336,13 +1336,6 @@ export default {
     align-items: flex-start;
   }
   
-  .trust-section {
-    gap: 20px;
-  }
-  
-  .trust-item {
-    flex: 1;
-  }
   
   .forgot-modal {
     padding: 32px 24px;
@@ -1374,15 +1367,6 @@ export default {
     font-size: 13px;
   }
   
-  .trust-section {
-    flex-direction: column;
-    gap: 16px;
-  }
-  
-  .trust-item {
-    flex-direction: row;
-    gap: 12px;
-  }
 }
 
 /* Accessibility */

--- a/src/components/auth/AuthModal.vue
+++ b/src/components/auth/AuthModal.vue
@@ -40,12 +40,6 @@
             <h2 class="auth-title">
               {{ isSignUp ? 'Create Your Account' : 'Welcome Back' }}
             </h2>
-            <p class="auth-subtitle">
-              {{ isSignUp 
-                ? 'Glow starts here ✨ Join our beauty community' 
-                : 'Sign in to your beautiful world 🌸' 
-              }}
-            </p>
           </div>
         </div>
 
@@ -243,21 +237,6 @@
           </p>
         </div>
 
-        <!-- Trust Indicators -->
-        <div class="trust-section">
-          <div class="trust-item">
-            <i class="fas fa-shield-alt"></i>
-            <span>Secure</span>
-          </div>
-          <div class="trust-item">
-            <i class="fas fa-user-shield"></i>
-            <span>Private</span>
-          </div>
-          <div class="trust-item">
-            <i class="fas fa-heart"></i>
-            <span>Trusted</span>
-          </div>
-        </div>
       </div>
     </div>
 

--- a/src/components/layout/AppHeader.vue
+++ b/src/components/layout/AppHeader.vue
@@ -1087,8 +1087,8 @@ export default {
 .user-dropdown-menu .dropdown-item {
   display: flex;
   align-items: center;
-  gap: 16px;
-  padding: 16px 20px;
+  gap: 12px;
+  padding: 10px 16px;
   color: var(--gray-700);
   text-decoration: none;
   transition: all 0.2s ease;

--- a/src/components/layout/AppHeader.vue
+++ b/src/components/layout/AppHeader.vue
@@ -1107,14 +1107,14 @@ export default {
 }
 
 .item-icon {
-  width: 40px;
-  height: 40px;
-  border-radius: 10px;
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
   background: var(--gray-100);
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 16px;
+  font-size: 14px;
   transition: all 0.2s ease;
   flex-shrink: 0;
 }

--- a/src/components/layout/AppHeader.vue
+++ b/src/components/layout/AppHeader.vue
@@ -1072,14 +1072,14 @@ export default {
 }
 
 .user-details h4 {
-  font-size: 18px;
+  font-size: 16px;
   font-weight: 600;
   color: var(--gray-800);
-  margin: 0 0 4px;
+  margin: 0 0 2px;
 }
 
 .user-details p {
-  font-size: 14px;
+  font-size: 13px;
   color: var(--gray-600);
   margin: 0;
 }

--- a/src/components/layout/AppHeader.vue
+++ b/src/components/layout/AppHeader.vue
@@ -1042,12 +1042,12 @@ export default {
 }
 
 .dropdown-header {
-  padding: 20px;
+  padding: 16px;
   background: linear-gradient(135deg, var(--primary-50) 0%, var(--purple-50) 100%);
   border-radius: 16px 16px 0 0;
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: 12px;
 }
 
 .user-avatar-large {

--- a/src/components/layout/AppHeader.vue
+++ b/src/components/layout/AppHeader.vue
@@ -1103,7 +1103,7 @@ export default {
 .user-dropdown-menu .dropdown-item:hover {
   background: var(--gray-50);
   color: var(--primary-600);
-  padding-left: 24px;
+  padding-left: 20px;
 }
 
 .item-icon {

--- a/src/components/layout/AppHeader.vue
+++ b/src/components/layout/AppHeader.vue
@@ -317,6 +317,16 @@ export default {
       this.isUserMenuOpen = false;
     },
 
+    handleSignInClick() {
+      this.closeUserMenu();
+      this.openSignIn();
+    },
+
+    handleSignUpClick() {
+      this.closeUserMenu();
+      this.openSignUp();
+    },
+
     handleAuthSuccess(data) {
       this.showNotification({
         type: 'success',

--- a/src/components/layout/AppHeader.vue
+++ b/src/components/layout/AppHeader.vue
@@ -217,6 +217,11 @@
         <i class="fas fa-box"></i>
         My Orders
       </router-link>
+      <router-link to="/wishlist" class="mobile-nav-link" @click="closeMobileMenu">
+        <i class="fas fa-heart"></i>
+        Wishlist
+        <span v-if="wishlistCount > 0" class="mobile-badge">{{ wishlistCount }}</span>
+      </router-link>
       <router-link to="/profile?tab=settings" class="mobile-nav-link" @click="closeMobileMenu">
         <i class="fas fa-cog"></i>
         Settings

--- a/src/components/layout/AppHeader.vue
+++ b/src/components/layout/AppHeader.vue
@@ -1187,7 +1187,7 @@ export default {
 .dropdown-divider {
   height: 1px;
   background: var(--gray-200);
-  margin: 8px 20px;
+  margin: 4px 16px;
 }
 
 .mobile-only {

--- a/src/components/layout/AppHeader.vue
+++ b/src/components/layout/AppHeader.vue
@@ -128,7 +128,7 @@
               <i class="fas fa-chevron-right item-arrow"></i>
             </router-link>
 
-            <button @click="openSignIn" class="dropdown-item" @click="closeUserMenu">
+            <button @click="handleSignInClick" class="dropdown-item">
               <div class="item-icon">
                 <i class="fas fa-sign-in-alt"></i>
               </div>
@@ -139,7 +139,7 @@
               <i class="fas fa-chevron-right item-arrow"></i>
             </button>
 
-            <button @click="openSignUp" class="dropdown-item" @click="closeUserMenu">
+            <button @click="handleSignUpClick" class="dropdown-item">
               <div class="item-icon">
                 <i class="fas fa-user-plus"></i>
               </div>

--- a/src/components/layout/AppHeader.vue
+++ b/src/components/layout/AppHeader.vue
@@ -800,6 +800,20 @@ export default {
   color: var(--primary-800) !important;
 }
 
+.mobile-badge {
+  background: var(--primary-500);
+  color: white;
+  border-radius: 50%;
+  min-width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  font-weight: 600;
+  margin-left: auto;
+}
+
 @media (max-width: 1024px) {
   .desktop-nav {
     display: none;

--- a/src/components/layout/AppHeader.vue
+++ b/src/components/layout/AppHeader.vue
@@ -116,16 +116,39 @@
               <i class="fas fa-chevron-right item-arrow"></i>
             </router-link>
 
-            <router-link to="/returns" class="dropdown-item" @click="closeUserMenu">
+            <router-link to="/wishlist" class="dropdown-item" @click="closeUserMenu">
               <div class="item-icon">
-                <i class="fas fa-undo-alt"></i>
+                <i class="fas fa-heart"></i>
               </div>
               <div class="item-content">
-                <span class="item-title">Returns & Refunds</span>
-                <span class="item-description">Easy returns process</span>
+                <span class="item-title">Wishlist</span>
+                <span class="item-description">Your saved items</span>
               </div>
+              <div class="item-badge" v-if="wishlistCount > 0">{{ wishlistCount }}</div>
               <i class="fas fa-chevron-right item-arrow"></i>
             </router-link>
+
+            <button @click="openSignIn" class="dropdown-item" @click="closeUserMenu">
+              <div class="item-icon">
+                <i class="fas fa-sign-in-alt"></i>
+              </div>
+              <div class="item-content">
+                <span class="item-title">Sign In</span>
+                <span class="item-description">Access your account</span>
+              </div>
+              <i class="fas fa-chevron-right item-arrow"></i>
+            </button>
+
+            <button @click="openSignUp" class="dropdown-item" @click="closeUserMenu">
+              <div class="item-icon">
+                <i class="fas fa-user-plus"></i>
+              </div>
+              <div class="item-content">
+                <span class="item-title">Sign Up</span>
+                <span class="item-description">Create new account</span>
+              </div>
+              <i class="fas fa-chevron-right item-arrow"></i>
+            </button>
 
             <router-link to="/profile?tab=settings" class="dropdown-item" @click="closeUserMenu">
               <div class="item-icon">

--- a/src/components/layout/AppHeader.vue
+++ b/src/components/layout/AppHeader.vue
@@ -1051,8 +1051,8 @@ export default {
 }
 
 .user-avatar-large {
-  width: 56px;
-  height: 56px;
+  width: 48px;
+  height: 48px;
   border-radius: 50%;
   overflow: hidden;
   background: linear-gradient(135deg, var(--primary-100), var(--primary-200));
@@ -1060,9 +1060,9 @@ export default {
   align-items: center;
   justify-content: center;
   color: var(--primary-600);
-  font-size: 24px;
-  border: 3px solid white;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  font-size: 20px;
+  border: 2px solid white;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 }
 
 .user-avatar-large img {


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR improves the profile section UI by:
- Adding sign in and sign up options with text descriptions for better accessibility
- Adding wishlist functionality with item count badges
- Removing the returns & refunds section as requested
- Removing trust indicators and promotional text that were cluttering the interface
- Improving overall spacing and visibility of profile elements

## Code changes

**AuthModal.vue:**
- Removed auth subtitle text ("Sign in to your beautiful world 🌸" and "Glow starts here ✨")
- Removed trust indicators section (Secure, Private, Trusted badges)
- Cleaned up associated CSS styles for removed elements

**AppHeader.vue:**
- Replaced "Returns & Refunds" with "Wishlist" in profile dropdown
- Added "Sign In" and "Sign Up" buttons with descriptive text
- Added wishlist count badges for both desktop and mobile views
- Implemented click handlers for sign in/up actions
- Reduced padding and sizing in dropdown for better space utilization
- Added wishlist link to mobile navigation with badge support

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 11`

🔗 [Edit in Builder.io](https://builder.io/app/projects/3b3d7ee4fbbb4d70ba767e0afd264183/spark-space)

👀 [Preview Link](https://3b3d7ee4fbbb4d70ba767e0afd264183-spark-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>3b3d7ee4fbbb4d70ba767e0afd264183</projectId>-->
<!--<branchName>spark-space</branchName>-->